### PR TITLE
Pass the target value as the rejected value

### DIFF
--- a/modules/cborm/models/validation/UniqueValidator.cfc
+++ b/modules/cborm/models/validation/UniqueValidator.cfc
@@ -61,7 +61,7 @@ component accessors="true" implements="cbvalidation.models.validators.IValidator
 
 			// validate uniqueness
 			if( c.count() GT 0 ){
-				var args = {message="The '#arguments.field#' value '#arguments.targetValue#' is not unique in the database",field=arguments.field,validationType=getName(),validationData=arguments.validationData};
+				var args = {message="The '#arguments.field#' value '#arguments.targetValue#' is not unique in the database",field=arguments.field,validationType=getName(),validationData=arguments.validationData, rejectedValue=arguments.targetValue};
 				validationResult.addError( validationResult.newError(argumentCollection=args) );
 				return false;
 			}


### PR DESCRIPTION
This enables custom error messages to show the rejected value correctly.