### PR TITLE
Fix getKey() return typing to allow composite keys

### DIFF
--- a/modules/cborm/models/VirtualEntityService.cfc
+++ b/modules/cborm/models/VirtualEntityService.cfc
@@ -178,7 +178,7 @@ component extends="cborm.models.BaseORMService" accessors="true"{
 		return super.getSessionStatistics(argumentCollection=arguments);
 	}
 
-	string function getKey(){
+	any function getKey(){
 		return super.getKey( this.getEntityName() );
 	}
 


### PR DESCRIPTION
If a composite primary key is in place, `getKey()` in the BaseORMService will return an array.  Changing the typing to account for this.