### PR TITLE
Workaround for ACF 2018 error when calling `sessionContains`

### DIFF
--- a/models/validation/UniqueValidator.cfc
+++ b/models/validation/UniqueValidator.cfc
@@ -46,7 +46,7 @@ component accessors="true" implements="cbvalidation.models.validators.IValidator
 		// Only validate simple values and if they have length, else ignore.
 		if( isSimpleValue( arguments.targetValue ) AND len( trim( arguments.targetValue ) ) ){
 			// process entity setups.
-			var entityName 		= ORMService.getEntityGivenName( arguments.target );
+			var entityName 		= arguments.target.getEntityName();
 			var identityField 	= ORMService.getKey( entityName );
 			var identityValue 	= evaluate( "arguments.target.get#identityField#()" );
 


### PR DESCRIPTION
This allows validation to proceed until the `sessionContains` method in BaseORM service can be refactored for ACF2018 compatibility